### PR TITLE
DPR2-2138 Enable HTTPS

### DIFF
--- a/helm_deploy/hmpps-dpr-tools-authoring-api/values.yaml
+++ b/helm_deploy/hmpps-dpr-tools-authoring-api/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local # override per environment
-    tlsSecretName: hmpps-dpr-tools-authoring-api-cert
+    tlsSecretName: hmpps-dpr-tools-cert
 
   # Environment variables to load into the deployment
   env:


### PR DESCRIPTION
The `tlsSecretName` in the configuration was automatically populated from the job that created this repository.
This does not exist.
This change references the correct secret which holds the certificate for the DNS name of this service.
This PR follows the changes to add the ingress host to the list of DNS names in the K8s cluster for which the certificate should be issued:
https://github.com/ministryofjustice/cloud-platform-environments/pull/36392